### PR TITLE
Align profile JSON with overlay script

### DIFF
--- a/ecthelion_profile.json
+++ b/ecthelion_profile.json
@@ -1,879 +1,408 @@
 {
-  "characterData": {
-    "meta": {
-      "version": "1.0",
-      "source": "lebowskigrande_149789668.docx",
-      "notes": "Auto-constructed from the uploaded Word doc. You can edit any fields to match your overlay's schema."
+  "name": "Ecthelion",
+  "profBonus": 3,
+  "abilities": {
+    "STR": {
+      "score": 13,
+      "mod": 1,
+      "save": 1
     },
-    "identity": {
-      "name": "Ecthelion",
-      "player": "lebowskigrande",
-      "classes": [
-        {
-          "class": "Paladin",
-          "level": 1
-        },
-        {
-          "class": "Warlock",
-          "level": 6,
-          "subclass": "Celestial"
-        }
-      ],
-      "species": "Dragonborn (Silver)",
-      "background": "Custom Background",
-      "alignment": null
+    "DEX": {
+      "score": 14,
+      "mod": 2,
+      "save": 2
     },
-    "proficiencyBonus": 3,
-    "speed": {
-      "walk": 30,
-      "fly": 0
+    "CON": {
+      "score": 14,
+      "mod": 2,
+      "save": 2
     },
-    "senses": {
-      "darkvision": 60,
-      "passivePerception": 9,
-      "passiveInsight": 9,
-      "passiveInvestigation": 9
+    "INT": {
+      "score": 8,
+      "mod": -1,
+      "save": -1
     },
-    "defenses": {
-      "resistances": [
-        "Cold",
-        "Radiant"
-      ],
-      "immunities": [
-        "Charmed",
-        "Frightened"
-      ]
+    "WIS": {
+      "score": 9,
+      "mod": -1,
+      "save": 2
     },
-    "armorClass": 20,
-    "initiativeMod": 2,
-    "hp": {
-      "max": 54,
-      "current": 54,
-      "temp": 0,
-      "hitDice": "1d10 + 6d8"
+    "CHA": {
+      "score": 18,
+      "mod": 4,
+      "save": 7
+    }
+  },
+  "attacks": [
+    {
+      "name": "Dragonspear",
+      "abl": "CHA",
+      "prof": true,
+      "misc": 0,
+      "magic": 1,
+      "dmg1": "1d6",
+      "dmg1type": "Piercing",
+      "dmg2": "1d6",
+      "dmg2type": "Fire",
+      "addAblToDamage": true,
+      "damageBonus": 0,
+      "range": "5 ft"
     },
-    "abilities": {
-      "str": {
-        "score": 13,
-        "mod": 1,
-        "save": 1,
-        "prof": false
-      },
-      "dex": {
-        "score": 14,
-        "mod": 2,
-        "save": 2,
-        "prof": false
-      },
-      "con": {
-        "score": 14,
-        "mod": 2,
-        "save": 2,
-        "prof": false
-      },
-      "int": {
-        "score": 8,
-        "mod": -1,
-        "save": -1,
-        "prof": false
-      },
-      "wis": {
-        "score": 9,
-        "mod": -1,
-        "save": 2,
-        "prof": true
-      },
-      "cha": {
-        "score": 18,
-        "mod": 4,
-        "save": 7,
-        "prof": true
-      }
+    {
+      "name": "True Strike",
+      "abl": "CHA",
+      "prof": true,
+      "misc": 0,
+      "magic": 1,
+      "dmg1": "3d6",
+      "dmg1type": "Radiant",
+      "addAbleToDamage": true,
+      "damageBonus": 4,
+      "range": "5 ft"
     },
-    "skills": {
-      "acrobatics": {
-        "mod": 5,
-        "prof": true,
-        "ability": "dex"
-      },
-      "animalHandling": {
-        "mod": -1,
-        "prof": false,
-        "ability": "wis"
-      },
-      "arcana": {
-        "mod": 2,
-        "prof": true,
-        "ability": "int"
-      },
-      "athletics": {
-        "mod": 1,
-        "prof": false,
-        "ability": "str"
-      },
-      "deception": {
-        "mod": 4,
-        "prof": false,
-        "ability": "cha"
-      },
-      "history": {
-        "mod": -1,
-        "prof": false,
-        "ability": "int"
-      },
-      "insight": {
-        "mod": -1,
-        "prof": false,
-        "ability": "wis"
-      },
-      "intimidation": {
-        "mod": 4,
-        "prof": false,
-        "ability": "cha"
-      },
-      "investigation": {
-        "mod": -1,
-        "prof": false,
-        "ability": "int"
-      },
-      "medicine": {
-        "mod": -1,
-        "prof": false,
-        "ability": "wis"
-      },
-      "nature": {
-        "mod": -1,
-        "prof": false,
-        "ability": "int"
-      },
-      "perception": {
-        "mod": -1,
-        "prof": false,
-        "ability": "wis"
-      },
-      "performance": {
-        "mod": 7,
-        "prof": true,
-        "ability": "cha"
-      },
-      "persuasion": {
-        "mod": 7,
-        "prof": true,
-        "ability": "cha"
-      },
-      "religion": {
-        "mod": 2,
-        "prof": true,
-        "ability": "int"
-      },
-      "sleightOfHand": {
-        "mod": 2,
-        "prof": false,
-        "ability": "dex"
-      },
-      "stealth": {
-        "mod": 5,
-        "prof": true,
-        "ability": "dex"
-      },
-      "survival": {
-        "mod": -1,
-        "prof": false,
-        "ability": "wis"
-      }
+    {
+      "name": "Leafwarden",
+      "abl": "CHA",
+      "prof": true,
+      "misc": 0,
+      "magic": 1,
+      "dmg1": "1d8",
+      "dmg1type": "Slashing",
+      "addAblToDamage": true,
+      "damageBonus": 0,
+      "range": "5 ft"
     },
-    "proficiencies": {
-      "armor": [
-        "Light",
-        "Medium",
-        "Heavy",
-        "Shields"
-      ],
-      "weapons": [
-        "Simple Weapons",
-        "Martial Weapons"
-      ],
-      "tools": [
-        "Longhorn",
-        "Lyre",
-        "Smith's Tools",
-        "Thelarr",
-        "Woodcarver's Tools"
-      ],
-      "languages": [
-        "Common",
-        "Draconic",
-        "Elvish"
-      ]
+    {
+      "name": "Leafwarden vs. Dragons",
+      "abl": "CHA",
+      "prof": true,
+      "misc": 0,
+      "magic": 1,
+      "dmg1": "1d8+3d6",
+      "dmg1type": "Slashing",
+      "addAblToDamage": true,
+      "damageBonus": 0,
+      "range": "5 ft"
+    }
+  ],
+  "spellSlots": {
+    "1": {
+      "max": 2
+    }
+  },
+  "pactSlots": {
+    "3": {
+      "max": 2
+    }
+  },
+  "features": [
+    {
+      "name": "Lay on Hands",
+      "text": "Your blessed touch can heal wounds. You have a pool of healing power that replenishes when you finish a Long Rest. With that pool, you can restore a total number of Hit Points equal to five times your Paladin level.\n\nAs a Bonus Action, you can touch a creature (which could be yourself) and draw power from the pool of healing to restore a number of Hit Points to that creature, up to the maximum amount remaining in the pool.\n\nYou can also expend 5 Hit Points from the pool of healing power to remove the Poisoned condition from the creature; those points don’t also restore Hit Points to the creature.",
+      "chargesMax": 5
     },
-    "features": {
-      "species": [
-        {
-          "name": "Draconic Ancestry (Silver)",
-          "type": "species",
-          "uses": {
-            "value": 3,
-            "max": 3,
-            "recharge": "longRest"
-          },
-          "short": "Breath weapon (cold): 15-ft cone or 30-ft line (5-ft wide). Dex save DC 13, 2d10 cold (half on success).",
-          "long": "When you take the Attack action, you can replace one attack with a cold breath weapon in a 15‑ft. cone or 30‑ft. by 5‑ft. line. Each creature makes a DC 13 Dex save, taking 2d10 cold damage on a failure or half as much on success."
-        },
-        {
-          "name": "Draconic Flight",
-          "type": "species",
-          "uses": {
-            "value": 1,
-            "max": 1,
-            "recharge": "longRest"
-          },
-          "short": "Bonus Action: gain fly speed equal to speed for 10 minutes.",
-          "long": "Once per long rest as a bonus action, spectral wings grant a fly speed equal to your speed for 10 minutes or until retracted or you are incapacitated."
-        },
-        {
-          "name": "Darkvision",
-          "type": "species",
-          "short": "60 ft."
-        },
-        {
-          "name": "Cold Resistance",
-          "type": "species",
-          "short": "Resistance to cold damage."
-        }
-      ],
-      "class": [
-        {
-          "name": "Pact Magic",
-          "class": "Warlock",
-          "level": 6
-        },
-        {
-          "name": "Magical Cunning",
-          "class": "Warlock",
-          "level": 2,
-          "uses": {
-            "value": 1,
-            "max": 1,
-            "recharge": "longRest"
-          }
-        },
-        {
-          "name": "Celestial Spells",
-          "class": "Warlock (Celestial)"
-        },
-        {
-          "name": "Healing Light",
-          "class": "Warlock (Celestial)",
-          "uses": {
-            "value": 7,
-            "max": 7,
-            "die": "d6",
-            "recharge": "longRest"
-          }
-        },
-        {
-          "name": "Radiant Soul",
-          "class": "Warlock (Celestial)",
-          "short": "+4 once per turn to radiant or fire spell damage."
-        },
-        {
-          "name": "Lay on Hands",
-          "class": "Paladin",
-          "level": 1,
-          "pool": 5
-        }
-      ],
-      "invocations": [
-        {
-          "name": "Pact of the Blade",
-          "short": "Bond or conjure a pact weapon. Can use CHA for attacks, set damage type to necrotic/psychic/radiant."
-        },
-        {
-          "name": "Pact of the Chain",
-          "short": "Learn Find Familiar and special familiar attack interaction."
-        },
-        {
-          "name": "Thirsting Blade",
-          "short": "Extra Attack with the pact weapon."
-        },
-        {
-          "name": "Eldritch Smite",
-          "short": "On hit with pact weapon, expend pact slot to add 4d8 force and knock prone (Huge or smaller)."
-        }
-      ],
-      "feats": [
-        {
-          "name": "War Caster",
-          "short": "Advantage on Con saves to maintain concentration; cast a spell instead of an OA; perform somatics with hands full."
-        },
-        {
-          "name": "Musician",
-          "short": "Instrument proficiency; grant Heroic Inspiration to up to 3 allies after a rest."
-        },
-        {
-          "name": "Skilled",
-          "short": "Gain three proficiencies (baked into skills/tools above)."
-        }
-      ]
+    {
+      "name": "Weapon Mastery",
+      "text": "Your training with weapons allows you to use the mastery properties of two kinds of weapons of your choice with which you have proficiency.\n\nWhenever you finish a Long Rest, you can change the kinds of weapons you chose.\n\nWeapons: Spear (Sap), Longsword (Sap).\nSap. If you hit a creature with a Spear, that creature has Disadvantage on its next attack roll before the start of your next turn."
     },
-    "attacks": [
+    {
+      "name": "Pact of the Chain",
+      "text": "You learn the Find Familiar spell and can cast it as a Magic action without expending a spell slot.\n\nWhen you cast the spell, you choose one of the normal forms for your familiar or one of the following special forms: Imp, Pseudodragon, Quasit, Skeleton, Slaad Tadpole, Sphinx of Wonder, Sprite, or Venomous Snake.\n\nAdditionally, when you take the Attack action on your turn, you can forgo one of your own attacks to allow your familiar to make one attack of its own with its Reaction."
+    },
+    {
+      "name": "Pact of the Blade",
+      "text": "As a Bonus Action, you can conjure a pact weapon in your hand—a Simple or Martial Melee weapon of your choice with which you bond—or create a bond with a magic weapon you touch; you can’t bond with a magic weapon if someone else is attuned to it or another Warlock is bonded with it. Until the bond ends, you have proficiency with the weapon, and you can use it as a Spellcasting Focus.\n\nWhenever you attack with the bonded weapon, you can use your Charisma modifier for the attack and damage rolls instead of using Strength or Dexterity; and you can cause the weapon to deal Necrotic, Psychic, or Radiant damage or its normal damage type.\n\nYour bond with the weapon ends if you use this feature’s Bonus Action again, if the weapon is more than 5 feet away from you for 1 minute or more, or if you die. A conjured weapon disappears when the bond ends."
+    },
+    {
+      "name": "Thirsting Blade",
+      "text": "You gain the Extra Attack feature for your pact weapon only. With that feature, you can attack twice with the weapon instead of once when you take the Attack action on your turn."
+    },
+    {
+      "name": "Eldritch Smite",
+      "text": "Once per turn when you hit a creature with your pact weapon, you can expend a Pact Magic spell slot to deal an extra 1d8 Force damage to the target, plus another 1d8 per level of the spell slot, and you can give the target the Prone condition if it is Huge or smaller."
+    },
+    {
+      "name": "Lessons of the First Ones",
+      "text": "You have received knowledge from an elder entity of the multiverse, allowing you to gain one Origin feat of your choice."
+    },
+    {
+      "name": "Healing Light",
+      "text": "You gain the ability to channel celestial energy to heal wounds. You have a pool of d6s to fuel this healing. The number of dice in the pool equals 1 plus your Warlock level.\n\nAs a Bonus Action, you can heal yourself or one creature you can see within 60 feet of yourself, expending dice from the pool. The maximum number of dice you can expend at once equals your Charisma modifier (minimum of one die). Roll the dice you expend, and restore a number of Hit Points equal to the roll’s total. Your pool regains all expended dice when you finish a Long Rest.",
+      "chargesMax": 6
+    },
+    {
+      "name": "Breath Weapon",
+      "text": "When you take the Attack action on your turn, you can replace one of your attacks with an exhalation of magical energy in either a 15-foot Cone or a 30-foot Line that is 5 feet wide (choose the shape each time). Each creature in that area must make a Dexterity saving throw (DC 8 plus your Constitution modifier and Proficiency Bonus). On a failed save, a creature takes 1d10 Cold damage. On a successful save, a creature takes half as much damage. This damage increases by 1d10 when you reach character levels 5 (2d10), 11 (3d10), and 17 (4d10).\n\nYou can use this Breath Weapon a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest.",
+      "chargesMax": 3
+    },
+    {
+      "name": "Draconic Resistance",
+      "text": "You have resistance to Cold Damage."
+    },
+    {
+      "name": "Draconic Flight",
+      "text": "When you reach character level 5, you can channel draconic magic to give yourself temporary flight. As a Bonus Action, you sprout spectral wings on your back that last for 10 minutes or until you retract the wings (no action required) or have the Incapacitated condition. During that time, you have a Fly Speed equal to your Speed. Your wings appear to be made of the same energy as your Breath Weapon. Once you use this trait, you can’t use it again until you finish a Long Rest.",
+      "chargesMax": 1
+    },
+    {
+      "name": "War Caster",
+      "text": "Concentration. You have Advantage on Constitution saving throws that you make to maintain Concentration.\n\nReactive Spell. When a creature provokes an Opportunity Attack from you by leaving your reach, you can take a Reaction to cast a spell at the creature rather than making an Opportunity Attack. The spell must have a casting time of one action and must target only that creature.\n\nSomatic Components. You can perform the Somatic components of spells even when you have weapons or a Shield in one or both hands."
+    },
+    {
+      "name": "Smite",
+      "text": "Quick smite roller for Divine (1st) and Eldritch (3rd).\nPick slot(s) and options, then roll. Pact → Force (3d8 at 2nd). Spell → Radiant (2d8; +1d8 vs Undead). Crit doubles dice.",
+      "smiteLauncher": true
+    },
+    {
+      "name": "Magical Cunning",
+      "text": "You can perform an esoteric rite for 1 minute. At the end of it, you regain expended Pact Magic spell slots but no more than a number equal to half your maximum (round up). Once you use this feature, you can’t do so again until you finish a Long Rest.",
+      "chargesMax": 1
+    },
+    {
+      "name": "Radiant Soul",
+      "text": "Your link to your patron allows you to serve as a conduit for radiant energy. You have Resistance to Radiant damage. Once per turn, when a spell you cast deals Radiant or Fire damage, you can add your Charisma modifier to that spell’s damage against one of the spell’s targets."
+    }
+  ],
+  "skills": [
+    {
+      "key": "Acrobatics",
+      "abl": "DEX",
+      "prof": true
+    },
+    {
+      "key": "Animal Handling",
+      "abl": "WIS",
+      "prof": false
+    },
+    {
+      "key": "Arcana",
+      "abl": "INT",
+      "prof": true
+    },
+    {
+      "key": "Athletics",
+      "abl": "STR",
+      "prof": false
+    },
+    {
+      "key": "Deception",
+      "abl": "CHA",
+      "prof": false
+    },
+    {
+      "key": "History",
+      "abl": "INT",
+      "prof": false
+    },
+    {
+      "key": "Insight",
+      "abl": "WIS",
+      "prof": false
+    },
+    {
+      "key": "Intimidation",
+      "abl": "CHA",
+      "prof": false
+    },
+    {
+      "key": "Investigation",
+      "abl": "INT",
+      "prof": false
+    },
+    {
+      "key": "Medicine",
+      "abl": "WIS",
+      "prof": false
+    },
+    {
+      "key": "Nature",
+      "abl": "INT",
+      "prof": true
+    },
+    {
+      "key": "Perception",
+      "abl": "WIS",
+      "prof": false
+    },
+    {
+      "key": "Performance",
+      "abl": "CHA",
+      "prof": true
+    },
+    {
+      "key": "Persuasion",
+      "abl": "CHA",
+      "prof": true
+    },
+    {
+      "key": "Religion",
+      "abl": "INT",
+      "prof": true
+    },
+    {
+      "key": "Sleight of Hand",
+      "abl": "DEX",
+      "prof": false
+    },
+    {
+      "key": "Stealth",
+      "abl": "DEX",
+      "prof": true
+    },
+    {
+      "key": "Survival",
+      "abl": "WIS",
+      "prof": false
+    }
+  ],
+  "spells": [
+    {
+      "level": 0,
+      "name": "Eldritch Blast",
+      "components": {
+        "v": true,
+        "s": true,
+        "m": false
+      },
+      "ritual": false,
+      "concentration": false,
+      "short": "Make a ranged spell attack; on hit, 1d10 force.",
+      "long": "Beam(s) of crackling energy streak toward a creature. At higher character levels, you create additional beams.",
+      "cast": null,
+      "macro": "&{template:atkdmg} {{rname=Eldritch Blast}} {{attack=1}} {{r1=[[1d20+@{selected|spell_attack_bonus}]]}} {{always=1}} {{r2=[[1d20+@{selected|spell_attack_bonus}]]}} {{damage=1}} {{dmg1=[[1d10]]}} {{dmg1type=Force}} {{charname=Ecthelion}}"
+    },
+    {
+      "level": 1,
+      "name": "Bless",
+      "components": {
+        "v": true,
+        "s": true,
+        "m": true
+      },
+      "ritual": false,
+      "concentration": true,
+      "short": "+1d4 to attacks & saves (conc).",
+      "long": "Up to three creatures of your choice gain a +1d4 bonus to attack rolls and saving throws while you maintain Concentration.",
+      "cast": {
+        "kind": "spell",
+        "slotLevel": 1
+      },
+      "macro": "/em casts Bless (up to 3 creatures gain +1d4 to attacks & saves while concentrating)."
+    },
+    {
+      "level": 1,
+      "name": "Shield of Faith",
+      "components": {
+        "v": true,
+        "s": true,
+        "m": true
+      },
+      "ritual": false,
+      "concentration": true,
+      "short": "+2 AC (conc).",
+      "long": "A shimmering field appears and gives +2 AC for the duration while you maintain Concentration.",
+      "cast": {
+        "kind": "spell",
+        "slotLevel": 1
+      },
+      "macro": "/em casts Shield of Faith (+2 AC, Concentration)."
+    },
+    {
+      "level": 2,
+      "name": "Invisibility",
+      "components": {
+        "v": true,
+        "s": true,
+        "m": true
+      },
+      "ritual": false,
+      "concentration": true,
+      "short": "Turn a creature invisible (conc).",
+      "long": "A creature you touch becomes invisible until the spell ends. The spell ends early if the target attacks or casts a spell.",
+      "cast": {
+        "kind": "spell",
+        "slotLevel": 2
+      },
+      "macro": "/em casts Invisibility (Concentration)."
+    },
+    {
+      "level": 3,
+      "name": "Spirit Shroud",
+      "components": {
+        "v": true,
+        "s": true,
+        "m": false
+      },
+      "ritual": false,
+      "concentration": true,
+      "short": "Attacks deal +1d8 cold/rad/nec; speed reduced (conc).",
+      "long": "You call forth spirits to assist you, dealing +1d8 extra damage (cold, radiant, or necrotic of your choice) on your attacks; affected targets can’t regain HP and have -10 ft speed while you concentrate.",
+      "cast": {
+        "kind": "spell",
+        "slotLevel": 3
+      },
+      "macro": "/em casts Spirit Shroud (choose damage type; Concentration)."
+    },
+    {
+      "level": 3,
+      "name": "Thunder Step",
+      "components": {
+        "v": true,
+        "s": true,
+        "m": false
+      },
+      "ritual": false,
+      "concentration": false,
+      "short": "Teleport; thunder damage at origin.",
+      "long": "You teleport up to 90 ft, and each creature within 10 ft of the space you left takes thunder damage on a failed save.",
+      "cast": {
+        "kind": "spell",
+        "slotLevel": 3
+      },
+      "macro": "&{template:atkdmg} {{rname=Thunder Step}} {{damage=1}} {{dmg1=[[3d10]]}} {{dmg1type=Thunder}} {{charname=Ecthelion}}"
+    }
+  ],
+  "inventory": {
+    "magic": [
       {
-        "name": "Dragon Slayer Longsword",
-        "type": "weapon",
-        "toHit": 5,
-        "dice": "1d8",
-        "dmgType": "Slashing",
-        "bonus": 2,
-        "properties": [
-          "Martial",
-          "Versatile",
-          "Mastery: Sap"
-        ],
-        "riders": [
-          "True Strike: +1d6+4 Radiant vs marked target (see feature)."
-        ]
-      },
-      {
-        "name": "Dragon's Wrath Spear (Slumbering)",
-        "type": "weapon",
-        "toHit": 8,
-        "dice": "1d6",
-        "dmgType": "Radiant",
-        "bonus": 5,
-        "properties": [
-          "Simple",
-          "Thrown (20/60)",
-          "Mastery: Sap"
-        ],
-        "riders": [
-          "+1d6 Cold",
-          "True Strike: +1d6+4 Radiant"
-        ]
-      },
-      {
-        "name": "Shortsword",
-        "type": "weapon",
-        "toHit": 5,
-        "dice": "1d6",
-        "dmgType": "Piercing",
-        "bonus": 2,
-        "properties": [
-          "Martial",
-          "Finesse",
-          "Light",
-          "Mastery: Vex"
-        ]
-      },
-      {
-        "name": "Eldritch Blast",
-        "type": "cantrip",
-        "toHit": 7,
-        "dice": "1d10",
-        "dmgType": "Force",
-        "count": 2,
-        "components": [
-          "V",
-          "S"
-        ]
+        "name": "Dragon's Wrath Spear",
+        "rarity": "rare"
       },
       {
-        "name": "Unarmed Strike",
-        "type": "weapon",
-        "toHit": 4,
-        "flatDamage": 2,
-        "dmgType": "Bludgeoning"
+        "name": "Dragonslayer Longsword",
+        "rarity": "rare"
+      },
+      {
+        "name": "Enspelled Breastplate",
+        "rarity": "uncommon",
+        "chargesMax": 6
+      },
+      {
+        "name": "Shield +1",
+        "rarity": "uncommon"
+      },
+      {
+        "name": "Scaled Ornament",
+        "rarity": "uncommon"
+      },
+      {
+        "name": "Adamantine Breastplate",
+        "rarity": "uncommon"
+      },
+      {
+        "name": "Instrument of Illusions",
+        "rarity": "common"
       }
     ],
-    "equipment": {
-      "attuned": [
-        "Scaled Ornament (Stirring)",
-        "Breastplate of Agathys",
-        "Dragon Vessel (Stirring)"
-      ],
-      "items": [
-        {
-          "name": "Shield +1",
-          "qty": 1,
-          "weight": 6
-        },
-        {
-          "name": "Adamantine Breastplate",
-          "qty": 1,
-          "weight": 20
-        },
-        {
-          "name": "Dragon Slayer Longsword",
-          "qty": 1,
-          "weight": 3
-        },
-        {
-          "name": "Dragon's Wrath Spear",
-          "qty": 1,
-          "weight": 3
-        },
-        {
-          "name": "Shortsword",
-          "qty": 1,
-          "weight": 2
-        },
-        {
-          "name": "Spear",
-          "qty": 1,
-          "weight": 3
-        },
-        {
-          "name": "Backpack",
-          "qty": 1,
-          "weight": 5
-        },
-        {
-          "name": "Crowbar",
-          "qty": 1,
-          "weight": 5
-        },
-        {
-          "name": "Hammer",
-          "qty": 1,
-          "weight": 3
-        },
-        {
-          "name": "Holy Water (flask)",
-          "qty": 1,
-          "weight": 1
-        },
-        {
-          "name": "Manacles",
-          "qty": 1,
-          "weight": 6
-        },
-        {
-          "name": "Mirror, Steel",
-          "qty": 1,
-          "weight": 0.5
-        },
-        {
-          "name": "Oil (flask)",
-          "qty": 1,
-          "weight": 1
-        },
-        {
-          "name": "Chest",
-          "qty": 1,
-          "weight": 25
-        },
-        {
-          "name": "Tinderbox",
-          "qty": 1,
-          "weight": 1
-        },
-        {
-          "name": "Torch",
-          "qty": 3,
-          "weight": 3
-        },
-        {
-          "name": "Potion of Healing",
-          "qty": 2,
-          "weight": 1
-        },
-        {
-          "name": "Instrument of Illusions (Longhorn)",
-          "qty": 1
-        },
-        {
-          "name": "Dragon Vessel (Stirring)",
-          "qty": 1
-        },
-        {
-          "name": "Scaled Ornament (Stirring)",
-          "qty": 1
-        },
-        {
-          "name": "Breastplate of Agathys",
-          "qty": 1
-        }
-      ],
-      "coins": {
-        "cp": 0,
-        "sp": 0,
-        "ep": 0,
-        "gp": 89,
-        "pp": 0
+    "mundane": [
+      {
+        "name": "Rations (days)",
+        "qty": 5
       },
-      "carriedWeight": 115,
-      "encumberedAt": 195,
-      "pushDragLift": 390
-    },
-    "spellcasting": {
-      "spellAttackBonus": {
-        "paladin": 7,
-        "warlock": 7
-      },
-      "saveDC": {
-        "paladin": 15,
-        "warlock": 15
-      },
-      "slots": {
-        "pact": {
-          "level": 3,
-          "current": 2,
-          "max": 2
-        },
-        "level1": {
-          "current": 2,
-          "max": 2
-        },
-        "level2": {
-          "current": 0,
-          "max": 0
-        },
-        "level3": {
-          "current": 0,
-          "max": 0
-        }
-      },
-      "spellsByLevel": {
-        "0": [
-          {
-            "name": "True Strike",
-            "classes": [
-              "Warlock"
-            ],
-            "toHit": 7,
-            "time": "1 Action",
-            "range": "Self",
-            "components": [
-              "S",
-              "M"
-            ],
-            "duration": "Instant",
-            "short": "Empower a weapon strike (house rule in build)."
-          },
-          {
-            "name": "Eldritch Blast",
-            "classes": [
-              "Warlock"
-            ],
-            "toHit": 7,
-            "time": "1 Action",
-            "range": "120 ft",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "Instant",
-            "notes": "2 beams at this level."
-          },
-          {
-            "name": "Light",
-            "classes": [
-              "Warlock (Celestial Spells)"
-            ],
-            "prepared": true,
-            "time": "1 Action",
-            "range": "Touch",
-            "components": [
-              "V",
-              "M"
-            ],
-            "duration": "1 hour"
-          },
-          {
-            "name": "Sacred Flame",
-            "classes": [
-              "Warlock (Celestial Spells)"
-            ],
-            "save": "DEX 15",
-            "time": "1 Action",
-            "range": "60 ft",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "Instant"
-          }
-        ],
-        "1": [
-          {
-            "name": "Divine Smite",
-            "classes": [
-              "Paladin"
-            ],
-            "time": "1 Bonus Action",
-            "range": "Self",
-            "components": [
-              "V"
-            ],
-            "duration": "Instant"
-          },
-          {
-            "name": "Divine Favor",
-            "classes": [
-              "Paladin"
-            ],
-            "time": "1 Bonus Action",
-            "range": "Self",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "1 minute",
-            "concentration": true
-          },
-          {
-            "name": "Armor of Agathys",
-            "classes": [
-              "Warlock"
-            ],
-            "time": "1 Bonus Action",
-            "range": "Self",
-            "components": [
-              "V",
-              "S",
-              "M"
-            ],
-            "duration": "1 hour",
-            "concentration": false
-          },
-          {
-            "name": "Hex",
-            "classes": [
-              "Warlock"
-            ],
-            "time": "1 Bonus Action",
-            "range": "90 ft",
-            "components": [
-              "V",
-              "S",
-              "M"
-            ],
-            "duration": "Up to 1 hour",
-            "concentration": true
-          },
-          {
-            "name": "Hellish Rebuke",
-            "classes": [
-              "Warlock"
-            ],
-            "time": "Reaction",
-            "range": "60 ft",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "Instant",
-            "save": "DEX 15"
-          },
-          {
-            "name": "Cure Wounds",
-            "classes": [
-              "Celestial Spells"
-            ],
-            "time": "1 Action",
-            "range": "Touch",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "Instant",
-            "prepared": true
-          },
-          {
-            "name": "Guiding Bolt",
-            "classes": [
-              "Celestial Spells"
-            ],
-            "time": "1 Action",
-            "range": "120 ft",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "1 round",
-            "prepared": true
-          },
-          {
-            "name": "Find Familiar",
-            "classes": [
-              "Eldritch Invocation"
-            ],
-            "time": "1 Action",
-            "range": "10 ft",
-            "components": [
-              "V",
-              "S",
-              "M"
-            ],
-            "duration": "Instant",
-            "ritual": true
-          }
-        ],
-        "2": [
-          {
-            "name": "Invisibility",
-            "classes": [
-              "Warlock"
-            ],
-            "time": "1 Action",
-            "range": "Touch",
-            "components": [
-              "V",
-              "S",
-              "M"
-            ],
-            "duration": "Up to 1 hour",
-            "concentration": true
-          },
-          {
-            "name": "Aid",
-            "classes": [
-              "Celestial Spells"
-            ],
-            "time": "1 Action",
-            "range": "30 ft",
-            "components": [
-              "V",
-              "S",
-              "M"
-            ],
-            "duration": "8 hours",
-            "prepared": true
-          },
-          {
-            "name": "Lesser Restoration",
-            "classes": [
-              "Celestial Spells"
-            ],
-            "time": "1 Bonus Action",
-            "range": "Touch",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "Instant",
-            "prepared": true
-          }
-        ],
-        "3": [
-          {
-            "name": "Spirit Shroud",
-            "classes": [
-              "Warlock"
-            ],
-            "time": "1 Bonus Action",
-            "range": "Self",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "Up to 1 minute",
-            "concentration": true
-          },
-          {
-            "name": "Thunder Step",
-            "classes": [
-              "Warlock"
-            ],
-            "time": "1 Action",
-            "range": "90 ft",
-            "components": [
-              "V"
-            ],
-            "duration": "Instant",
-            "save": "CON 15"
-          },
-          {
-            "name": "Dispel Magic",
-            "classes": [
-              "Warlock"
-            ],
-            "time": "1 Action",
-            "range": "120 ft",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "Instant"
-          },
-          {
-            "name": "Daylight",
-            "classes": [
-              "Celestial Spells"
-            ],
-            "time": "1 Action",
-            "range": "60 ft / 60‑ft sphere",
-            "components": [
-              "V",
-              "S"
-            ],
-            "duration": "1 hour",
-            "prepared": true
-          },
-          {
-            "name": "Revivify",
-            "classes": [
-              "Celestial Spells"
-            ],
-            "time": "1 Action",
-            "range": "Touch",
-            "components": [
-              "V",
-              "S",
-              "M"
-            ],
-            "duration": "Instant",
-            "prepared": true
-          }
-        ]
+      {
+        "name": "Rope (50 ft)",
+        "qty": 1
       }
-    },
-    "resources": {
-      "breathWeapon": {
-        "uses": {
-          "value": 0,
-          "max": 3,
-          "recharge": "longRest"
-        }
-      },
-      "draconicFlight": {
-        "uses": {
-          "value": 0,
-          "max": 1,
-          "recharge": "longRest"
-        }
-      },
-      "healingLight": {
-        "dicePool": {
-          "value": 7,
-          "size": "d6"
-        },
-        "recharge": "longRest"
-      },
-      "layOnHands": {
-        "pool": {
-          "value": 5,
-          "max": 5
-        },
-        "recharge": "longRest"
-      },
-      "pactSlots": {
-        "level": 3,
-        "value": 2,
-        "max": 2,
-        "recharge": "shortRest"
-      }
-    },
-    "ui": {
-      "rollTemplates": {
-        "simple": [
-          "rname",
-          "mod",
-          "r1",
-          "always",
-          "r2",
-          "charname"
-        ]
-      }
-    }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- Restructure `ecthelion_profile.json` to match overlay script schema
- Use uppercase ability keys, rename profBonus, and convert skills, attacks, features, spells, and inventory to expected arrays

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('ecthelion_profile.json','utf8')); console.log('JSON valid');"`


------
https://chatgpt.com/codex/tasks/task_e_68a6838eb9d8832184a98ec783af2cdb